### PR TITLE
Disable pushing docker images on PR workflow run

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,7 +2,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['master']
+    branches: ['**']
   pull_request:
     branches: ['master']
 
@@ -52,6 +52,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
So the workflow runs on any PR that is done to the repo, which is fine, it validates that the new code passes "bun run build" without errors, so syntax errors and such will automatically generate an error on the PR.

But right now it also tries to push the generated image, which fails, because I don't have permission to push images to `ghcr.io/defaultkavy-dev`. So no vulnerability there, just a failed build in the PR.

After merging this PR it should:
* For PRs: Does a dry-run. i.e. does the whole docker build (including `bun run build`), but does not make a push. The PR will get a nice :heavy_check_mark:  if the docker build succeeds.
* For branch pushes (any branch): It does the build AND the push. This only works for branches pushed directly to the repo. So me pushing a branch on my fork will not publish an image on your repo.
 
This way when I push a branch to my fork I'll get a docker image on my repo, on `ghcr.io/kebien6020`, and if you want to use branches in your repo (you don't have to, but if you want), then you'll get also a docker image for the branch.